### PR TITLE
adding support for cli options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,12 @@ inputs:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
   stylelint_input:
-    description: "Files or glob. Default: `**/*.css`.  It's same as `[input]` of stylelint."
+    description: "Files or glob. Default: `**/*.css`.  It's the same as `[input]` of stylelint."
     default: '**/*.css'
+  stylelint_ignore:
+    description: "Files or glob. It's the same as `--ignore-pattern` of stylelint"
+  stylelint_config:
+    description: "It's the same as `--config` flag of stylelint."
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,4 @@ npm install -g stylelint@$(jq -r '.dependencies.stylelint // .devDependencies.st
 
 stylelint --version
 
-stylelint "${INPUT_STYLELINT_INPUT:-'**/*.css'}" | reviewdog -f="stylelint" -reporter="github-pr-check" -level="${INPUT_LEVEL}"
+stylelint --allow-empty-input --ignore-pattern "${INPUT_STYLELINT_IGNORE}" --config "${INPUT_STYLELINT_CONFIG}" "${INPUT_STYLELINT_INPUT:-'**/*.css'}" | reviewdog -f="stylelint" -reporter="github-pr-check" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
this is for temporary support while we transition to tailwindcss
* added `--ignore-pattern` - ignore tailwind css files
* added `--allow-empty-input` - don't throw an error if no files
* added `--config` - allow for custom rc file